### PR TITLE
Update instructions for running the site locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ The [book now](book-now.md) page can be added as a button above the menu; the co
 
 If you want to add a brand new page, you just need to add it, and add it to the menu if appropriate.
 
+## How to handle internal navigation
+
+The Lead a session pages have internal navigation. Follow the pattern in [_includes/lead-a-session-nav.html](_includes/lead-a-session-nav.html) to add or remove pages from the internal navigation. Make sure new pages have `has-nav: lead-a-session` in the yaml front matter. (See for example [lead-a-session.md](/lead-a-session.md).)
+
 ## If a page is no longer needed
 
 When a page has passed its time, DO NOT REMOVE IT, but comment it out in the menu if it appears. For example, the lead a session page will no longer be used after the CFP has closed, but should not become a 404; instead, update it to say the CFP has closed and remove it from the menu.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,25 @@ In addition, previous conference sites are left in situ once the year changes. T
 
 You will need [jekyll](https://jekyllrb.com/docs/quickstart/) to run the site locally, and [html-proofer](https://rubygems.org/gems/html-proofer/) to run the tests locally.
 
-Follow the commands in [/scripts/build.sh](/scripts/build.sh).
+To run the site locally:
 
-The output of the first command will tell you where the site is running locally (something like `localhost:4000/$conference_year/`).
+```
+bundle exec jekyll serve --watch
+```
+
+The `--watch` means that you will not have to restart the server to see changes reflected on your locally running site. However, you always need to restart if you make changes to `_config.yml`.
+
+The output of this command will tell you where the site is running locally. It will be something like `localhost:4000/$conference_year/` (note the closing slash).
+
+`$conference_year` is whatever is set as the `baseurl` in [_config.yml](_config.yml).
+
+To run the tests locally:
+
+```
+bundle exec htmlproofer --assume-extension --url-swap $conference_year: ./_site
+```
+
+where `$conference_year` is as above, the `baseurl` in [_config.yml](_config.yml).
 
 ## To update the site
 


### PR DESCRIPTION
This PR adds explicit instructions for running the site locally, as the previous instructions assumed some knowledge of jekyll.

It also adds instructions on how to change the internal navigation of the lead a session pages, which have their own menu.

@jennyd, as you will be making these changes and raised the original point that the instructions weren't clear, please could you review this and see if it makes sense to you, and if so, merge?

cc @eoinwoods @NTCoding as you are also collaborators and may wish to comment.