### PR TITLE
Use new conference name everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ bundle exec jekyll serve --watch
 
 The `--watch` means that you will not have to restart the server to see changes reflected on your locally running site. However, you always need to restart if you make changes to `_config.yml`.
 
-The output of this command will tell you where the site is running locally. It will be something like `localhost:4000/$conference_year/` (note the closing slash).
+The output of this command will tell you where the site is running locally. It will be something like `localhost:4000/$base_url/` (note the closing slash).
 
-`$conference_year` is whatever is set as the `baseurl` in [_config.yml](_config.yml).
+`$base_url` is whatever is set as the `baseurl` in [_config.yml](_config.yml).
 
 To run the tests locally:
 
 ```
-bundle exec htmlproofer --assume-extension --url-swap $conference_year: ./_site
+bundle exec htmlproofer --assume-extension --url-swap $base_url: ./_site
 ```
 
-where `$conference_year` is as above, the `baseurl` in [_config.yml](_config.yml).
+where `$base_url` is as above, the `baseurl` in [_config.yml](_config.yml).
 
 ## To update the site
 

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,6 @@ baseurl: /spa2018
 
 conference:
   current_year: 2017
-  conference_year: SPA2018
   name: SPA Software in Practice
   name_with_year: SPA Software in Practice 2018
   dates: 2nd &ndash; 4th July 2018

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ conference:
   current_year: 2017
   conference_year: SPA2018
   name_html: <span class="conference-name">SPA<wbr><em>2018</em></span>
+  name: SPA Software in Practice
   name_with_year: SPA Software in Practice 2018
   dates: 2nd &ndash; 4th July 2018
   cfp_open_date: 30th November 2017

--- a/_config.yml
+++ b/_config.yml
@@ -28,5 +28,6 @@ conference:
   current_year: 2017
   conference_year: SPA2018
   name_html: <span class="conference-name">SPA<wbr><em>2018</em></span>
+  name_with_year: SPA Software in Practice 2018
   dates: 2nd &ndash; 4th July 2018
   cfp_open_date: 30th November 2017

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,6 @@ baseurl: /spa2018
 conference:
   current_year: 2017
   conference_year: SPA2018
-  name_html: <span class="conference-name">SPA<wbr><em>2018</em></span>
   name: SPA Software in Practice
   name_with_year: SPA Software in Practice 2018
   dates: 2nd &ndash; 4th July 2018

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
     <footer>
       <div>
         <p>&copy; BCS SPA, 2016-{{ site.conference.current_year }}.</p>
-        <p>{{ site.conference.name_html }} is organised by
+        <p>{{ site.conference.name_with_year }} is organised by
           <a href="http://www.bcs-spa.org/">SPA</a>
           which is a specialist group of the
           <a href="http://www.bcs.org/">BCS</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,7 +26,7 @@
 <header><div>
   <h1>
     <img alt="BCS" src="{{ '/images/bcslogo.png' | relative_url }}" width="65" height="81">
-    <a href="{{ '/' | relative_url }}">{{ site.conference.name_html }}</a>
+    <a href="{{ '/' | relative_url }}">{{ site.conference.name }}</a>
   </h1>
 
   {% if page.url == "/" %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
     {% if page.url == "/" %}
-      <title>{{ site.conference.conference_year }} conference</title>
+      <title>{{ site.conference.name_with_year }} conference</title>
     {% else %}
-      <title>{{ page.title }} - {{ site.conference.conference_year }}</title>
+      <title>{{ page.title }} - {{ site.conference.name_with_year }}</title>
     {% endif %}
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,7 +30,6 @@
   </h1>
 
   {% if page.url == "/" %}
-    <h2>Software in Practice</h2>
     <p>{{ site.conference.dates }}</p>
   {% endif %}
 

--- a/bofs.md
+++ b/bofs.md
@@ -6,7 +6,7 @@ layout: page
 <h1>All about BOFs</h1>
 <h2>What is a BOF?</h2>
 <p>"Birds of a Feather" sessions are meetings that you organise at the conference, about topics that you want to discuss.</p>
-<p>The SPA Software in Practice conference continues the great tradition of knowledge sharing between all participants, not just the session leaders. BOF sessions are an important and popular way of doing this.</p>
+<p>The {{ site.conference.name }} conference continues the great tradition of knowledge sharing between all participants, not just the session leaders. BOF sessions are an important and popular way of doing this.</p>
 <h2>How do I set up a BOF?</h2>
 <p>Slots are available for BOFs on each day of the programme. There will be a noticeboard on which to propose BOFs using the cards that will be available in your delegate pack. Additional cards will also be available at the organisers' desk. Interested delegates can sign up by adding their name to the card. The organisers will assign rooms based on the number of interested parties.</p>
 <h2>How do I run a BOF?</h2>

--- a/bofs.md
+++ b/bofs.md
@@ -6,7 +6,7 @@ layout: page
 <h1>All about BOFs</h1>
 <h2>What is a BOF?</h2>
 <p>"Birds of a Feather" sessions are meetings that you organise at the conference, about topics that you want to discuss.</p>
-<p>The Software Practice Advancement conference continues the great tradition of knowledge sharing between all participants, not just the session leaders. BOF sessions are an important and popular way of doing this.</p>
+<p>The SPA Software in Practice conference continues the great tradition of knowledge sharing between all participants, not just the session leaders. BOF sessions are an important and popular way of doing this.</p>
 <h2>How do I set up a BOF?</h2>
 <p>Slots are available for BOFs on each day of the programme. There will be a noticeboard on which to propose BOFs using the cards that will be available in your delegate pack. Additional cards will also be available at the organisers' desk. Interested delegates can sign up by adding their name to the card. The organisers will assign rooms based on the number of interested parties.</p>
 <h2>How do I run a BOF?</h2>

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: page
 ---
 <section><div class="inner">
 <h1>About the Conference</h1>
-<p>The annual BCS SPA Software in Practice conference brings together experts and practitioners to share the latest thinking in software development.</p>
+<p>The annual BCS {{ site.conference.name }} conference brings together experts and practitioners to share the latest thinking in software development.</p>
 <p>Now in its 23rd year, our conference has a tradition of active participation. We encourage conference sessions that bring people together to work and learn and in most cases, many sessions are highly interactive, involving participants and session leaders on an equal footing. This results in a conference like no other and consistently excellent feedback from all those who attend.</p>
 </div>
 </section>

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: page
 ---
 <section><div class="inner">
 <h1>About the Conference</h1>
-<p>The annual BCS Software Practice Advancement conference brings together experts and practitioners to share the latest thinking in software development.</p>
+<p>The annual BCS SPA Software in Practice conference brings together experts and practitioners to share the latest thinking in software development.</p>
 <p>Now in its 23rd year, our conference has a tradition of active participation. We encourage conference sessions that bring people together to work and learn and in most cases, many sessions are highly interactive, involving participants and session leaders on an equal footing. This results in a conference like no other and consistently excellent feedback from all those who attend.</p>
 </div>
 </section>

--- a/index.md
+++ b/index.md
@@ -11,8 +11,8 @@ layout: page
 <section><div class="inner">
 <h1>The location</h1>
 <img src="{{ '/images/bcs-london.jpg' | relative_url }}" alt="Photo of BCS office" width="300" height="300" class="round"/>
-<p>{{ site.conference.name_html }} will take place in the excellent facilities provided by The BCS’s London office. Located in the heart of London’s West End on Southampton Street, just a few moments walk from Covent Garden, the venue is easy to reach by public transport and is located near a wide range of hotels.</p>
- <a href="/location.html">More about the location.</a></div></section>
+<p>{{ site.conference.name_with_year }} will take place in the excellent facilities provided by The BCS’s London office. Located in the heart of London’s West End on Southampton Street, just a few moments walk from Covent Garden, the venue is easy to reach by public transport and is located near a wide range of hotels.</p>
+<a href="/location.html">More about the location.</a></div></section>
 
 <section><div class="inner">
 <h1>Organisers</h1>

--- a/interactivity.md
+++ b/interactivity.md
@@ -1,5 +1,5 @@
 ---
-title: Lead a session at SPA Software in Practice
+title: Lead a session
 layout: page
 has-nav: lead-a-session
 ---

--- a/interactivity.md
+++ b/interactivity.md
@@ -1,5 +1,5 @@
 ---
-title: Lead a session at SPA
+title: Lead a session at SPA Software in Practice
 layout: page
 has-nav: lead-a-session
 ---

--- a/interactivity.md
+++ b/interactivity.md
@@ -5,7 +5,7 @@ has-nav: lead-a-session
 ---
 
 <h1>How can I make my session interactive?</h1>
-<p>Every session at SPA Software in Practice is interactive in some way. To help you think about this aspect of your session here are some ways of getting people to participate. Most sessions include some presentation material as well as interactive elements.</p>
+<p>Every session at {{ site.conference.name }} is interactive in some way. To help you think about this aspect of your session here are some ways of getting people to participate. Most sessions include some presentation material as well as interactive elements.</p>
 <p>Some practical details to consider: Sessions are 75 or 150 minutes long. Room capacity is 50, with seating around tables for working in groups, and you’ll be able to present slides.</p>
 <h2>Practice</h2>
 <p>If the aim of your session is to teach people how to do something or to help them understand why it’s important or a good thing to do, get them to try doing it! Plan short exercises to structure the time. Workshops would typically spend a significant amount of time on this.</p>

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -5,20 +5,20 @@ has-nav: lead-a-session
 ---
 
 <h1>Propose a session</h1>
-<p>SPA Software in Practice is about practitioners from any aspect of software development - technology, people and process - sharing their thoughts and knowledge, and learning together.</p>
+<p>{{ site.conference.name }} is about practitioners from any aspect of software development - technology, people and process - sharing their thoughts and knowledge, and learning together.</p>
 <p>All the sessions are interactive - everyone can be an active participant and learn by doing.</p>
 
 <h2>What are we looking for?</h2>
 <p>We welcome a wide variety of perspectives on all aspects of software development - new ideas, old ideas rediscovered, creativity, the unexpected, reflection and fun. In the past we’ve had sessions on programming languages, tools, techniques, design, architecture, testing, coaching, team dynamics, pairing and organising a team’s work.</p>
 <p>We’ve also had some great sessions on topics you might not expect at a software conference, like sketching, speed reading, and education. We really like sessions like this too - they give us more opportunities to think about and try a wide range of things.</p>
-<p>At SPA Software in Practice you can experiment and try something new, or bring a session you’ve perfected elsewhere - we value both. All submissions get feedback to help them improve, and accepted sessions will be assigned a shepherd to help with preparation so we’ll support you along the way.</p>
+<p>At {{ site.conference.name }} you can experiment and try something new, or bring a session you’ve perfected elsewhere - we value both. All submissions get feedback to help them improve, and accepted sessions will be assigned a shepherd to help with preparation so we’ll support you along the way.</p>
 <p>You can get an idea of the sort of sessions that have run previously from the websites for <a href="{{ '/previous-conferences.html' | relative_url }}">previous years' conferences</a>.</p>
 <p>But don't be constrained by any of these ideas; maybe you've got something totally new to bring. We'd like to hear it.</p>
 <p>We’d love to see in your proposal how you’ll make your session interactive and get participants involved. You can get some ideas of ways to do that from <a href="{{ 'interactivity.html' | relative_url }}">our page of suggestions for interactivity</a> or propose anything else you like.</p>
 
 <h2>Who do we want to hear from?</h2>
 <p>Anyone involved in the process of developing software, whatever your role - product manager, artist, developer, musician, business analyst, designer...</p>
-<p>We particularly encourage speakers who are new to presenting at SPA Software in Practice. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
+<p>We particularly encourage speakers who are new to presenting at {{ site.conference.name }}. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
 
 <h2>The submission and selection process</h2>
 <p>To submit your proposal, complete the <a href="http://spaconference.org/scripts/makeproposal.php">form on the website</a>.</p>
@@ -29,7 +29,7 @@ has-nav: lead-a-session
 
 <h2>What we offer</h2>
 <p>We will help you make your session the best it can be, both through our feedback process prior to the submissions deadline and our shepherding process if your session is accepted. More detail on these stages is <a href="{{ '/submission-stages.html' | relative_url }}">here</a>.</p>
-<p>The first two named presenters of each accepted session receive a free ticket to SPA Software in Practice. If you have already purchased a ticket before the programme is announced, you will receive a full refund. See <a href="{{ '/terms-and-conditions.html' | relative_url }}">here</a> for conditions.</p>
+<p>The first two named presenters of each accepted session receive a free ticket to {{ site.conference.name }}. If you have already purchased a ticket before the programme is announced, you will receive a full refund. See <a href="{{ '/terms-and-conditions.html' | relative_url }}">here</a> for conditions.</p>
 <p>The conference is not run for profit but we do have some funds available to help cover travel and accommodation expenses for speakers whose employer will not cover their expenses. If this applies to you, please tick the travel assistance box when you submit your proposal and we’ll get in touch if your talk is selected.</p>
 
 <h2>Important dates</h2>

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -1,5 +1,5 @@
 ---
-title: Lead a session at SPA Software in Practice
+title: Lead a session
 layout: page
 has-nav: lead-a-session
 ---

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -1,5 +1,5 @@
 ---
-title: Lead a session at SPA
+title: Lead a session at SPA Software in Practice
 layout: page
 has-nav: lead-a-session
 ---
@@ -11,14 +11,14 @@ has-nav: lead-a-session
 <h2>What are we looking for?</h2>
 <p>We welcome a wide variety of perspectives on all aspects of software development - new ideas, old ideas rediscovered, creativity, the unexpected, reflection and fun. In the past we’ve had sessions on programming languages, tools, techniques, design, architecture, testing, coaching, team dynamics, pairing and organising a team’s work.</p>
 <p>We’ve also had some great sessions on topics you might not expect at a software conference, like sketching, speed reading, and education. We really like sessions like this too - they give us more opportunities to think about and try a wide range of things.</p>
-<p>At SPA you can experiment and try something new, or bring a session you’ve perfected elsewhere - we value both. All submissions get feedback to help them improve, and accepted sessions will be assigned a shepherd to help with preparation so we’ll support you along the way.</p>
+<p>At SPA Software in Practice you can experiment and try something new, or bring a session you’ve perfected elsewhere - we value both. All submissions get feedback to help them improve, and accepted sessions will be assigned a shepherd to help with preparation so we’ll support you along the way.</p>
 <p>You can get an idea of the sort of sessions that have run previously from the websites for <a href="{{ '/previous-conferences.html' | relative_url }}">previous years' conferences</a>.</p>
 <p>But don't be constrained by any of these ideas; maybe you've got something totally new to bring. We'd like to hear it.</p>
 <p>We’d love to see in your proposal how you’ll make your session interactive and get participants involved. You can get some ideas of ways to do that from <a href="{{ 'interactivity.html' | relative_url }}">our page of suggestions for interactivity</a> or propose anything else you like.</p>
 
 <h2>Who do we want to hear from?</h2>
 <p>Anyone involved in the process of developing software, whatever your role - product manager, artist, developer, musician, business analyst, designer...</p>
-<p>We particularly encourage speakers who are new to presenting at SPA. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
+<p>We particularly encourage speakers who are new to presenting at SPA Software in Practice. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
 
 <h2>The submission and selection process</h2>
 <p>To submit your proposal, complete the <a href="http://spaconference.org/scripts/makeproposal.php">form on the website</a>.</p>
@@ -29,7 +29,7 @@ has-nav: lead-a-session
 
 <h2>What we offer</h2>
 <p>We will help you make your session the best it can be, both through our feedback process prior to the submissions deadline and our shepherding process if your session is accepted. More detail on these stages is <a href="{{ '/submission-stages.html' | relative_url }}">here</a>.</p>
-<p>The first two named presenters of each accepted session receive a free ticket to SPA. If you have already purchased a ticket before the programme is announced, you will receive a full refund. See <a href="{{ '/terms-and-conditions.html' | relative_url }}">here</a> for conditions.</p>
+<p>The first two named presenters of each accepted session receive a free ticket to SPA Software in Practice. If you have already purchased a ticket before the programme is announced, you will receive a full refund. See <a href="{{ '/terms-and-conditions.html' | relative_url }}">here</a> for conditions.</p>
 <p>The conference is not run for profit but we do have some funds available to help cover travel and accommodation expenses for speakers whose employer will not cover their expenses. If this applies to you, please tick the travel assistance box when you submit your proposal and we’ll get in touch if your talk is selected.</p>
 
 <h2>Important dates</h2>

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -39,4 +39,4 @@ has-nav: lead-a-session
 <p>Programme announced: 3rd April 2018</p>
 <p>If you're uncertain about whether to submit your idea, or have other queries, please feel free to get in touch with us at</p>
 <p><em>programme@spaconference.org</em></p>
-<p>Jenny Duckett and Melinda Seckington, Programme Chairs, SPA Software in Practice 2018</p>
+<p>Jenny Duckett and Melinda Seckington, Programme Chairs, {{ site.conference.name_with_year }}</p>

--- a/location.md
+++ b/location.md
@@ -3,7 +3,7 @@ title: Location
 layout: page
 ---
 
-{{ site.conference.name_html }} will take place in the BCS's London Office.
+{{ site.conference.name_with_year }} will take place in the BCS's London Office.
 
 <img style="margin: 15px 3px 15px 15px; float: right;" src="{{ '/images/BCSLondon.jpg' | relative_url }}" alt="BCS London entrance with clock" width="141" height="400" />
 

--- a/refunds-and-cancellations.md
+++ b/refunds-and-cancellations.md
@@ -13,4 +13,4 @@ layout: page
 <p>The booking fee covers attendance at the conference for both the formal sessions and informal activities for the days booked, social activities (diversions) on those days, lunch on the days booked and full conference documentation.</p>
 
 <h2>Changes to the conference</h2>
-<p>The programme details are subject to alteration without notice. Latest programme details will be displayed on this website. The SPA Specialist Group reserves the right to cancel any event. In the highly unlikely event that {conference_name} is cancelled, then a full refund will be given.</p>
+<p>The programme details are subject to alteration without notice. Latest programme details will be displayed on this website. The SPA Specialist Group reserves the right to cancel any event. In the highly unlikely event that {{ site.conference.name_with_year }} is cancelled, then a full refund will be given.</p>

--- a/sponsor.md
+++ b/sponsor.md
@@ -3,7 +3,7 @@ title: Sponsorship opportunities
 layout: page
 ---
 <p>{{ site.conference.name }} attracts many participants who are experts in their fields, and who often play a leading role in product and service recommendation and acquisition.</p>
-<p>Becoming a sponsor of {{ site.conference.name_html }} provides the highest possible profile at the event.</p>
+<p>Becoming a sponsor of {{ site.conference.name }} provides the highest possible profile at the event.</p>
 
 <h2>Sponsorship Benefits</h2>
 
@@ -40,4 +40,4 @@ layout: page
 </ul>
 
 <p></p>
-<p><a href="mailto:conference@spaconference.org?Subject={{ site.conference.conference_year }}%20Sponsorship" target="_top">Contact us</a> to discuss how sponsoring {{ site.conference.name_html }} can benefit your organisation.</p>
+<p><a href="mailto:conference@spaconference.org?Subject={{ site.conference.name }}%20Sponsorship" target="_top">Contact us</a> to discuss how sponsoring {{ site.conference.name }} can benefit your organisation.</p>

--- a/sponsor.md
+++ b/sponsor.md
@@ -2,16 +2,16 @@
 title: Sponsorship opportunities
 layout: page
 ---
-<p>SPA Software in Practice attracts many participants who are experts in their fields, and who often play a leading role in product and service recommendation and acquisition.</p>
+<p>{{ site.conference.name }} attracts many participants who are experts in their fields, and who often play a leading role in product and service recommendation and acquisition.</p>
 <p>Becoming a sponsor of {{ site.conference.name_html }} provides the highest possible profile at the event.</p>
 
 <h2>Sponsorship Benefits</h2>
 
 <h3>General Sponsorship - £1250 + 20% VAT (Three Available)</h3>
-<p>Be a core supporter of the SPA Software in Practice conference and gain prominent placement of your organisation and message to conference attendees leading up to and throughout the conference.</p>
+<p>Be a core supporter of the {{ site.conference.name }} conference and gain prominent placement of your organisation and message to conference attendees leading up to and throughout the conference.</p>
 <ul>
    <li>Large logo on the conference website</li>
-   <li>Placement of a short promotional message on the SPA Software in Practice conference website</li>
+   <li>Placement of a short promotional message on the {{ site.conference.name }} conference website</li>
    <li>Thanks and acknowledgement on conference social media channels</li>
    <li>Public thanks to the sponsor at conference plenary sessions</li>
    <li>Opportunity to give a 10 minute "lightning talk" at a plenary session</li>
@@ -31,7 +31,7 @@ layout: page
 </ul>
 
 <h3>Lunch Package - £750 + 20% VAT (Three Available)</h3>
-<p>Sponsor one of the conference lunches and gain attention from attendees as they are gathered together for one of SPA Software in Practice's buffet lunches, where attendees mingle and share their experiences of the conference that morning.</p>
+<p>Sponsor one of the conference lunches and gain attention from attendees as they are gathered together for one of {{ site.conference.name }}'s buffet lunches, where attendees mingle and share their experiences of the conference that morning.</p>
 <ul>
    <li>Public thanks to the sponsor at conference plenary sessions</li>
    <li>Opportunity to run a "brown bag" session for the conference attendees during the lunch break</li>

--- a/sponsor.md
+++ b/sponsor.md
@@ -2,16 +2,16 @@
 title: Sponsorship opportunities
 layout: page
 ---
-<p>SPA attracts many participants who are experts in their fields, and who often play a leading role in product and service recommendation and acquisition.</p>
+<p>SPA Software in Practice attracts many participants who are experts in their fields, and who often play a leading role in product and service recommendation and acquisition.</p>
 <p>Becoming a sponsor of {{ site.conference.name_html }} provides the highest possible profile at the event.</p>
 
 <h2>Sponsorship Benefits</h2>
 
 <h3>General Sponsorship - £1250 + 20% VAT (Three Available)</h3>
-<p>Be a core supporter of the SPA conference and gain prominent placement of your organisation and message to conference attendees leading up to and throughout the conference.</p>
+<p>Be a core supporter of the SPA Software in Practice conference and gain prominent placement of your organisation and message to conference attendees leading up to and throughout the conference.</p>
 <ul>
    <li>Large logo on the conference website</li>
-   <li>Placement of a short promotional message on the SPA conference website</li>
+   <li>Placement of a short promotional message on the SPA Software in Practice conference website</li>
    <li>Thanks and acknowledgement on conference social media channels</li>
    <li>Public thanks to the sponsor at conference plenary sessions</li>
    <li>Opportunity to give a 10 minute "lightning talk" at a plenary session</li>
@@ -31,7 +31,7 @@ layout: page
 </ul>
 
 <h3>Lunch Package - £750 + 20% VAT (Three Available)</h3>
-<p>Sponsor one of the conference lunches and gain attention from attendees as they are gathered together for one of SPA's buffet lunches, where attendees mingle and share their experiences of the conference that morning.</p>
+<p>Sponsor one of the conference lunches and gain attention from attendees as they are gathered together for one of SPA Software in Practice's buffet lunches, where attendees mingle and share their experiences of the conference that morning.</p>
 <ul>
    <li>Public thanks to the sponsor at conference plenary sessions</li>
    <li>Opportunity to run a "brown bag" session for the conference attendees during the lunch break</li>

--- a/sponsors.md
+++ b/sponsors.md
@@ -3,7 +3,7 @@ title: Sponsors
 layout: page
 ---
 
-<p>We are grateful to our conference sponsors for providing resources and time to make SPA Software in Practice 2018 a success.</p>
+<p>We are grateful to our conference sponsors for providing resources and time to make {{ site.conference.name_with_year }} a success.</p>
 
 <a href="https://www.contino.io" title="Contino">{image src="Contino_Logo_DarkGrey_Large_Web.png" width=600 height=218}
 </a> 

--- a/sponsors.md
+++ b/sponsors.md
@@ -3,7 +3,7 @@ title: Sponsors
 layout: page
 ---
 
-<p>We are grateful to our conference sponsors for providing resources and time to make SPA2017 a success.</p>
+<p>We are grateful to our conference sponsors for providing resources and time to make SPA Software in Practice 2018 a success.</p>
 
 <a href="https://www.contino.io" title="Contino">{image src="Contino_Logo_DarkGrey_Large_Web.png" width=600 height=218}
 </a> 

--- a/submission-stages.md
+++ b/submission-stages.md
@@ -1,5 +1,5 @@
 ---
-title: Lead a session at SPA Software in Practice
+title: Lead a session
 layout: page
 has-nav: lead-a-session
 ---

--- a/submission-stages.md
+++ b/submission-stages.md
@@ -44,4 +44,4 @@ has-nav: lead-a-session
 </ol></ol>
 <p>If you have any questions or would like to be involved, please contact us:</p>
 <p><em>programme@spaconference.org</em></p>
-<p>Jenny Duckett and Melinda Seckington, Programme Chairs, SPA Software in Practice 2018</p>
+<p>Jenny Duckett and Melinda Seckington, Programme Chairs, {{ site.conference.name_with_year }}</p>

--- a/submission-stages.md
+++ b/submission-stages.md
@@ -9,7 +9,7 @@ has-nav: lead-a-session
 <h2>Feedback</h2>
 <p>The feedback stage is between 1st February and 28th February.</p>
 <p>During the feedback stage, we look at all the sessions that were submitted by 1st February and give them feedback to improve the submission and help make it the best it can be before it goes into the review stage. Sessions can be modified and resubmitted until the hard deadline of 28th February.</p>
-<p>We like each submission to have at least three pieces of feedback, so sessions will be ordered such that those with fewest feedback items are at the top but it's up to you which sessions you give feedback on. The more feedback you have time to give, the better, as it can be very helpful to session proposers, especially those not as familiar with SPA Software in Practice or new to presenting.</p>
+<p>We like each submission to have at least three pieces of feedback, so sessions will be ordered such that those with fewest feedback items are at the top but it's up to you which sessions you give feedback on. The more feedback you have time to give, the better, as it can be very helpful to session proposers, especially those not as familiar with {{ site.conference.name }} or new to presenting.</p>
 <p>At this stage, feedback is seen by the submitter themselves along with everyone else who has access, so it's important to be constructive. Don't forget that some of these people may be submitting to a conference for the first time ever, and your comments may be the first feedback they have received for their conference proposal. The point of this stage is to help submitters make the best proposal they can so ask them to clarify things, suggest modifications to the session, and of course, positive feedback is welcome!</p>
 <h2>Review</h2>
 <p>The review stage is between 28th February and 14th March.</p>
@@ -24,14 +24,14 @@ has-nav: lead-a-session
 <p>We also make suggestions about the submissions - for example if we feel a session would be really good, but would require more shepherding.</p>
 <p>Submitters do not get notified of the reviews, but if they have been involved in the feedback stages (and we encourage everyone to get involved) they will have access so it's still important to be constructive. And it would be bad form to down-vote a session you see as a competitor to one you have submitted!</p>
 <p>Again, ideally we would like every session to receive at least three reviews so that we can be sure the conference will have wide appeal.</p>
-<p>We encourage everyone to get involved in reviewing as well, even if you haven't been to SPA Software in Practice before - the basis is whether you would like to attend the session or think it would be valuable.</p>
+<p>We encourage everyone to get involved in reviewing as well, even if you haven't been to {{ site.conference.name }} before - the basis is whether you would like to attend the session or think it would be valuable.</p>
 <h2>Programme meeting</h2>
 <p>The programme meeting will be in mid March 2016 in Central London. The exact timing and venue will be announced closer the time. If you would like to be involved in the programme meeting, please contact us.</p>
 <p>At this stage, submissions are still anonymous. We lay out cards with all the sessions and their scores, and formulate a draft programme. High scores are not the only thing we look at, as we want the programme to be as varied and balanced as possible, so we might not want four sessions on Node.js, for example. Those present are also given the opportunity to advocate for particular sessions, for example if it has received average reviews but they feel it would complement other sessions at the conference.</p>
 <p>We then reveal names to check that no-one has too many sessions in, or several at the same time.</p>
 <p>We will contact successful submitters after the programme meeting and we'll announce the programme in mid-April.</p>
 <h2>Shepherding</h2>
-<p>All presenters are assigned a shepherd. A shepherd is someone who has experience presenting, maybe at SPA Software in Practice, and ideally in a similar area to the session leaders. They offer advice and support to help people prepare their sessions, and may meet with the session leaders and perhaps help arrange dry-runs prior to the conference. (We do recommend that you have at least one dry-run of your session.)</p>
+<p>All presenters are assigned a shepherd. A shepherd is someone who has experience presenting, maybe at {{ site.conference.name }}, and ideally in a similar area to the session leaders. They offer advice and support to help people prepare their sessions, and may meet with the session leaders and perhaps help arrange dry-runs prior to the conference. (We do recommend that you have at least one dry-run of your session.)</p>
 <p>We are always looking for people to help shepherd, so please do let us know if you'd like to get involved in this.</p>
 <h2>Key dates</h2>
 <ol><ol>

--- a/submission-stages.md
+++ b/submission-stages.md
@@ -1,5 +1,5 @@
 ---
-title: Lead a session at SPA
+title: Lead a session at SPA Software in Practice
 layout: page
 has-nav: lead-a-session
 ---
@@ -9,7 +9,7 @@ has-nav: lead-a-session
 <h2>Feedback</h2>
 <p>The feedback stage is between 1st February and 28th February.</p>
 <p>During the feedback stage, we look at all the sessions that were submitted by 1st February and give them feedback to improve the submission and help make it the best it can be before it goes into the review stage. Sessions can be modified and resubmitted until the hard deadline of 28th February.</p>
-<p>We like each submission to have at least three pieces of feedback, so sessions will be ordered such that those with fewest feedback items are at the top but it's up to you which sessions you give feedback on. The more feedback you have time to give, the better, as it can be very helpful to session proposers, especially those not as familiar with SPA or new to presenting.</p>
+<p>We like each submission to have at least three pieces of feedback, so sessions will be ordered such that those with fewest feedback items are at the top but it's up to you which sessions you give feedback on. The more feedback you have time to give, the better, as it can be very helpful to session proposers, especially those not as familiar with SPA Software in Practice or new to presenting.</p>
 <p>At this stage, feedback is seen by the submitter themselves along with everyone else who has access, so it's important to be constructive. Don't forget that some of these people may be submitting to a conference for the first time ever, and your comments may be the first feedback they have received for their conference proposal. The point of this stage is to help submitters make the best proposal they can so ask them to clarify things, suggest modifications to the session, and of course, positive feedback is welcome!</p>
 <h2>Review</h2>
 <p>The review stage is between 28th February and 14th March.</p>
@@ -24,14 +24,14 @@ has-nav: lead-a-session
 <p>We also make suggestions about the submissions - for example if we feel a session would be really good, but would require more shepherding.</p>
 <p>Submitters do not get notified of the reviews, but if they have been involved in the feedback stages (and we encourage everyone to get involved) they will have access so it's still important to be constructive. And it would be bad form to down-vote a session you see as a competitor to one you have submitted!</p>
 <p>Again, ideally we would like every session to receive at least three reviews so that we can be sure the conference will have wide appeal.</p>
-<p>We encourage everyone to get involved in reviewing as well, even if you haven't been to SPA Conference before - the basis is whether you would like to attend the session or think it would be valuable.</p>
+<p>We encourage everyone to get involved in reviewing as well, even if you haven't been to SPA Software in Practice before - the basis is whether you would like to attend the session or think it would be valuable.</p>
 <h2>Programme meeting</h2>
 <p>The programme meeting will be in mid March 2016 in Central London. The exact timing and venue will be announced closer the time. If you would like to be involved in the programme meeting, please contact us.</p>
 <p>At this stage, submissions are still anonymous. We lay out cards with all the sessions and their scores, and formulate a draft programme. High scores are not the only thing we look at, as we want the programme to be as varied and balanced as possible, so we might not want four sessions on Node.js, for example. Those present are also given the opportunity to advocate for particular sessions, for example if it has received average reviews but they feel it would complement other sessions at the conference.</p>
 <p>We then reveal names to check that no-one has too many sessions in, or several at the same time.</p>
 <p>We will contact successful submitters after the programme meeting and we'll announce the programme in mid-April.</p>
 <h2>Shepherding</h2>
-<p>All presenters are assigned a shepherd. A shepherd is someone who has experience presenting, maybe at SPA, and ideally in a similar area to the session leaders. They offer advice and support to help people prepare their sessions, and may meet with the session leaders and perhaps help arrange dry-runs prior to the conference. (We do recommend that you have at least one dry-run of your session.)</p>
+<p>All presenters are assigned a shepherd. A shepherd is someone who has experience presenting, maybe at SPA Software in Practice, and ideally in a similar area to the session leaders. They offer advice and support to help people prepare their sessions, and may meet with the session leaders and perhaps help arrange dry-runs prior to the conference. (We do recommend that you have at least one dry-run of your session.)</p>
 <p>We are always looking for people to help shepherd, so please do let us know if you'd like to get involved in this.</p>
 <h2>Key dates</h2>
 <ol><ol>
@@ -44,4 +44,4 @@ has-nav: lead-a-session
 </ol></ol>
 <p>If you have any questions or would like to be involved, please contact us:</p>
 <p><em>programme@spaconference.org</em></p>
-<p>Jenny Duckett and Melinda Seckington, Programme Chairs, SPA 2018</p>
+<p>Jenny Duckett and Melinda Seckington, Programme Chairs, SPA Software in Practice 2018</p>

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -17,9 +17,9 @@ layout: page
 <p>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</p>
 
 <h3>Use of your data</h3>
-<p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the SPA Software in Practice website.</p>
+<p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the {{ site.conference.name }} website.</p>
 
-<p>If you have consented to receive emails about SPA Software in Practice, you may be contacted about being involved in the conference (for example, reviewing sessions, or submitting a proposal) and about future conferences.</p>
+<p>If you have consented to receive emails about {{ site.conference.name }}, you may be contacted about being involved in the conference (for example, reviewing sessions, or submitting a proposal) and about future conferences.</p>
 
 <p>Your information will not be shared with other groups.</p>
 

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -17,9 +17,9 @@ layout: page
 <p>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</p>
 
 <h3>Use of your data</h3>
-<p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the SPA conference website.</p>
+<p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the SPA Software in Practice website.</p>
 
-<p>If you have consented to receive emails about SPA conference, you may be contacted about being involved in the conference (for example, reviewing sessions, or submitting a proposal) and about future conferences.</p>
+<p>If you have consented to receive emails about SPA Software in Practice, you may be contacted about being involved in the conference (for example, reviewing sessions, or submitting a proposal) and about future conferences.</p>
 
 <p>Your information will not be shared with other groups.</p>
 

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -12,7 +12,7 @@ layout: page
 <li>By agreeing to have the session included in the programme the session leader is committing to participate in the shepherding process to ensure high session quality</li>
 </ol>
 
-<p>The session leader grants SPA the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</p>
+<p>The session leader grants the conference organisers the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</p>
 
 <p>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</p>
 


### PR DESCRIPTION
As agreed with @annashipman, update all website content to use the new conference name: SPA Software in Practice.