### PR TITLE
Update all spaconference.org links to use HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev # required to avoid SSL errors


### PR DESCRIPTION
We've moved the site to HTTPS today, and now the build has started failing
because these links return 301 redirects from http to https. Update the links
to fix the build.