### PR TITLE
Add clarification about deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ The Lead a session pages have internal navigation. Follow the pattern in [_inclu
 ## If a page is no longer needed
 
 When a page has passed its time, DO NOT REMOVE IT, but comment it out in the menu if it appears. For example, the lead a session page will no longer be used after the CFP has closed, but should not become a 404; instead, update it to say the CFP has closed and remove it from the menu.
+
+Please note, the deployment does not purge removed pages (because the programme is generated elsewhere and we do not want a deploy to delete the programme), so if there is a reason to remove a deployed page please contact the [administrator](mailto:website@spaconference.org).

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
+# Note this does not delete files that have been removed from the source, as the programme is generated outside of this project
+# and purging on deploy would remove the programme.
 rsync -avz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress _site/ $SSH_USER@$DEPLOY_HOST:public_html/$1


### PR DESCRIPTION
The deployment does not purge on deploy, which means that existing pages that are no longer present in the source are not removed. This is good because we should not be removing pages that have been published as that breaks existing links, and it is necessary because the programme is generated from the scripts part of the site and is deployed in a different way; if this purged on deploy it would delete the programme every time.