### PR TITLE
Ensure the new conference name isn't too wide

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,9 +29,7 @@
     <a href="{{ '/' | relative_url }}">{{ site.conference.name }}</a>
   </h1>
 
-  {% if page.url == "/" %}
     <p>{{ site.conference.dates }}</p>
-  {% endif %}
 
   <!--Button for booking now, is styled-->
   <!--<a href="{{ '/book-now.html' | relative_url }}" title="Book your place now"  class="cta">Book your place now</a>-->

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ layout: page
 
 <section><div class="inner">
 <h1>The location</h1>
-<img src="{{ '/images/bcs-london.jpg' | relative_url }}" alt="Photo of BCS office" width="300" height="300" class="round"/>
+<img src="{{ '/images/bcs-london.jpg' | relative_url }}" alt="Photo of BCS office" width="250" height="250" class="round"/>
 <p>{{ site.conference.name_with_year }} will take place in the excellent facilities provided by the BCS’s London office. Located in the heart of London’s West End on Southampton Street, just a few moments walk from Covent Garden, the venue is easy to reach by public transport and is located near a wide range of hotels.</p>
 <a href="{{ '/location.html' | relative_url }}">More about the location.</a></div></section>
 

--- a/spa.css
+++ b/spa.css
@@ -244,8 +244,6 @@ header h1 a:active {
 }
 
 header h1 {
-    font-size:              48px;
-    line-height:            60px;
     margin-bottom:          45px;
     padding-left:           96px;
 }

--- a/spa.css
+++ b/spa.css
@@ -222,7 +222,7 @@ header {
     line-height:            20px;
 }
 @supports (background-blend-mode:  multiply) {
-    .home header {
+    header {
         background-blend-mode:  multiply;
         background-image:       url(images/header-bg.jpg);
         background-repeat:      no-repeat;
@@ -247,14 +247,6 @@ header h1 {
     margin-bottom:          45px;
     padding-left:           96px;
 }
-header h1:after {
-    content:                '';
-    display:                block;
-    clear:                  both;
-}
-header h1 {
-    *zoom:                  1;
-}
 header h1 img {
   float: left;
   margin-right: 10px;
@@ -271,9 +263,6 @@ header p {
 header h2 {
     margin-bottom:          13px;
     margin-top:             -3px;
-}
-header p {
-    margin-bottom:          15px;
 }
 header .cta {
     border-color:           #fff;
@@ -319,6 +308,7 @@ header nav a:active {
     padding-left: 0;
   }
   header nav {
+    clear: left;
     margin-left: -96px;
   }
 }


### PR DESCRIPTION
On narrow devices (notably, iPhones 5/5S/SE) the new conference name, in a 48px face, is just wide enough that it induces horizontal scrolling. To counter that, let's just reduce the font size back to the default. This isn't a perfect fix but, given the current layout, it's probably the best compromise.

It turns out that the location image on the homepage is *also* wide enough to cause this issue, so I've fixed that.

This PR also puts the header image on all pages and the date on all pages as now homepage header is smaller, it looks odd removing the image from page to page.
