### PR TITLE
Programmatically generate the menubar from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Some of the common pages are already present in this repo but excluded from the 
 
 - update the page
 - comment it out in the exclusions section in [_config.yml](_config.yml).
-- if it appears in the menu, comment it in in [_includes/menu.html](_includes/menu.html)
+- if it appears in the menu, comment it in in the `conference.site_navigation` array in [_config.yml](_config.yml)
 
 The [book now](book-now.md) page can be added as a button above the menu; the code to do this is commented out in [_includes/header.html](_includes/header.html).
 

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,8 @@ exclude:
   # BELOW are pages that are not yet published for this year
   # Comment out from this list when published
   # DO NOT comment back in, we do not want 404s
-  # You can remove them from the menu (`_includes/menu.html`)
+  # You can remove them from the menu by editing
+  # conference.site_navigation, below
   - sponsors.md
   - refunds-and-cancellations.md
   - book-now.md
@@ -38,3 +39,19 @@ conference:
   programme_announce_date: mid-April 2018
   shepherding_dates: 1st April &ndash; conference
   ticket_refund_deadline: 20th June 2018
+  # This controls the site-wide navigation. Items should either be a
+  # dictionary containing url and title, or the filename of the page to
+  # link to (whose title will be the text of the link).
+  # The order here dictates the display order, and items can be removed
+  # by commenting out (or just deleting)
+  site_navigation:
+    - sponsor.md
+    # - sponsors.md
+    - lead-a-session.md
+    - organisers.md
+    - location.md
+    - previous-conferences.md
+    - code-of-conduct.md
+    -
+      url: https://spaconference.org/scripts/myprofile.php
+      title: My Spa

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,12 +1,40 @@
 <nav>
-  <ul>
-    <li><a href="{{ '/sponsor.html' | relative_url }}"><span>Sponsor us</span></a></li>
-    {% comment %}<li><a href="{{ '/sponsors.html' | relative_url }}"><span>Sponsors</span></a></li>{% endcomment %}
-    <li><a href="{{ '/lead-a-session.html' | relative_url }}"><span>Lead a session</span></a></li>
-    <li><a href="{{ '/organisers.html' | relative_url }}"><span>Organisers</span></a></li>
-    <li><a href="{{ '/location.html' | relative_url }}"><span>Location</span></a></li>
-    <li><a href="{{ '/previous-conferences.html' | relative_url }}"><span>Previous conferences</span></a></li>
-    <li><a href="{{ '/code-of-conduct.html' | relative_url }}"><span>Code of conduct</span></a></li>
-    <li><a href="https://spaconference.org/scripts/myprofile.php"><span>My Spa</span></a></li>
-  </ul>
+<ul>
+  {% for item in site.conference.site_navigation %}
+    {% if item.url and item.title %}
+      {% comment %}
+      If the menu item from the config is a dictionary with a URL and title,
+      just use those
+      {% endcomment %}
+
+      {% assign item_title = item.title %}
+      {% assign item_url = item.url %}
+    {% else %}
+      {% comment %}
+      Otherwise, assume the menu item is the name of a Markdown file in
+      the root of the site, find it, and grab *its* title and URL
+      {% endcomment %}
+
+      {% assign matching_pages = site.pages | where: "name", item %}
+      {% assign item_title = matching_pages[0].title %}
+      {% assign item_url = matching_pages[0].url | relative_url %}
+    {% endif %}
+
+    {% comment %}
+    If the current page's URL matches that of the current menu item, or
+    the page specifies that we should use the navigation from this menu
+    item, mark the menu item selected
+    {% endcomment %}
+    {% assign current_url = page.url | relative_url %}
+    {% if current_url == item_url or page.has-nav == item %}
+      {% assign item_selected = ' class="menuactive"'%}
+    {% else %}
+      {% assign item_selected = ""%}
+    {% endif %}
+
+    <li{{ item_selected }}><a href="{{ item_url }}">
+      <span>{{ item_title }}</span>
+    </a></li>
+  {% endfor %}
+</ul>
 </nav>

--- a/sponsor.md
+++ b/sponsor.md
@@ -1,5 +1,5 @@
 ---
-title: Sponsorship opportunities
+title: Sponsor us
 layout: page
 ---
 <p>{{ site.conference.name }} attracts many participants who are experts in their fields, and who often play a leading role in product and service recommendation and acquisition.</p>


### PR DESCRIPTION
The current menubar is easy to understand, but isn't easy to make show the currently active page. It also requires some duplication, making future markup changes more complicated.

This change moves the control of the navigation structure into the `_config.yml` (though it could possibly be done another way), and then uses that structure to generate the menu programmatically. Menu items are rendered in the order they're stored in the array, and may either be the ID of a page, or a dictionary (expected to contain both `title` and `url`, which we output without touching).

The rendering code checks if the menu item is either the current page, or is mentioned in the current page's `has-nav` attribute and, if true, marks the menu item as selected.