### PR TITLE
Add programme to the navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,9 @@ conference:
   # The order here dictates the display order, and items can be removed
   # by commenting out (or just deleting)
   site_navigation:
+    #-
+      #url: baseurl/programme.html
+      #title: Programme
     - sponsor.md
     # - sponsors.md
     - lead-a-session.md

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -8,7 +8,7 @@
       {% endcomment %}
 
       {% assign item_title = item.title %}
-      {% assign item_url = item.url %}
+      {% assign item_url = item.url  | replace: "baseurl", site.baseurl %}
     {% else %}
       {% comment %}
       Otherwise, assume the menu item is the name of a Markdown file in

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -2,29 +2,13 @@
 <ul>
   {% for item in site.conference.site_navigation %}
     {% if item.url and item.title %}
-      {% comment %}
-      If the menu item from the config is a dictionary with a URL and title,
-      just use those
-      {% endcomment %}
-
       {% assign item_title = item.title %}
       {% assign item_url = item.url  | replace: "baseurl", site.baseurl %}
     {% else %}
-      {% comment %}
-      Otherwise, assume the menu item is the name of a Markdown file in
-      the root of the site, find it, and grab *its* title and URL
-      {% endcomment %}
-
       {% assign matching_pages = site.pages | where: "name", item %}
       {% assign item_title = matching_pages[0].title %}
       {% assign item_url = matching_pages[0].url | relative_url %}
     {% endif %}
-
-    {% comment %}
-    If the current page's URL matches that of the current menu item, or
-    the page specifies that we should use the navigation from this menu
-    item, mark the menu item selected
-    {% endcomment %}
     {% assign current_url = page.url | relative_url %}
     {% if current_url == item_url or page.has-nav == item %}
       {% assign item_selected = ' class="menuactive"'%}


### PR DESCRIPTION
Since the programme is not generated from this Jekyll site, adding it to the navigation is a little complicated, so I have added this commented out in the config file.

I've also removed the comments from the menu include because to me, they actually made it harder to parse than without them.