### PR TITLE
Make age of conference a little more vague

### DIFF
--- a/previous-conferences.md
+++ b/previous-conferences.md
@@ -4,4 +4,4 @@ layout: page
 has-nav: previous-conferences
 ---
 
-The conference is now in its 23rd year. You can see an archive of the previous conference sites dating back to 1997.
+The conference has now been running for over 20 years. You can see an archive of the previous conference sites dating back to 1997.


### PR DESCRIPTION
Firstly, this year's claim (23rd year) doesn't match up with last year's claim (21st year), and I also think neither are correct and the conference has actuallybeen running longer than that. In any case, to avoid having to update this page every year with a possibly incorrect year, let's just say "over 20 years" and update it in 5 or 10 years :)