### PR TITLE
Support new programme rendering

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,6 +19,8 @@
 
   {% if page.url == "/" %}
     <body class="home">
+  {% else if page.url == "/programme_includes/header.html" %}
+    <body class="programme">
   {% else %}
     <body class="">
   {% endif %}

--- a/programme_includes/footer.html
+++ b/programme_includes/footer.html
@@ -1,0 +1,8 @@
+---
+---
+    </main>
+  </div>
+
+</div>
+
+{% include footer.html %}

--- a/programme_includes/header.html
+++ b/programme_includes/header.html
@@ -1,0 +1,13 @@
+---
+title: Programme
+---
+{% include header.html %}
+
+  <div id="main">
+
+      <header><h1 class="inner">
+        {{ page.title }}
+      </h1></header>
+      <div class="inner">
+
+    <main>

--- a/spa.css
+++ b/spa.css
@@ -524,6 +524,16 @@ header nav a:active {
     position:               absolute;
   }
 
+  .programme .four-tracks .track-1 {
+    width:                  34%;
+  }
+
+  .programme .four-tracks .track-2,
+  .programme .four-tracks .track-3,
+  .programme .four-tracks .track-4 {
+    width:                  22%;
+  }
+
   .programme .break {
     text-align:             center;
   }

--- a/spa.css
+++ b/spa.css
@@ -490,7 +490,7 @@ header nav a:active {
 }
 
 @media (min-width: 700px) {
-  .programme h3 {
+  .programme h3 .time {
     float:                  left;
     width:                  4em;
     max-width:              50%;
@@ -517,9 +517,9 @@ header nav a:active {
     width:                  30%;
   }
 
-  .programme .track-2 h3 span,
-  .programme .track-3 h3 span,
-  .programme .track-4 h3 span {
+  .programme .track-2 .time,
+  .programme .track-3 .time,
+  .programme .track-4 .time {
     left:                   -999em;
     position:               absolute;
   }

--- a/spa.css
+++ b/spa.css
@@ -509,16 +509,17 @@ header nav a:active {
     width:                  100%;
   }
 
-  .programme .track-a {
+  .programme .track-1 {
     width:                  40%;
   }
-  .programme .track-b,
-  .programme .track-c {
+  .programme .track-2,
+  .programme .track-3 {
     width:                  30%;
   }
-  .programme .track-a h3 span,
-  .programme .track-b h3,
-  .programme .track-c h3 {
+
+  .programme .track-2 h3 span,
+  .programme .track-3 h3 span,
+  .programme .track-4 h3 span {
     left:                   -999em;
     position:               absolute;
   }


### PR DESCRIPTION
The programme is generated using the PHP scripts and is published by the chairs via the PHP on the main site. However, it needs to look like the rest of the site and reflect any updates to header and footer, so this PR adds a header and footer that will be included with the programme.

I've also made some changes to the design of the programme so that if there are 4 tracks rather than 3 it looks right, and to have it include the actual room names so it is a useful tool during the conference itself. This PR includes changes to the CSS required to support that.