### PR TITLE
Blog post typos and dates

### DIFF
--- a/_posts/2018-02-28-launching-spa-2018.md
+++ b/_posts/2018-02-28-launching-spa-2018.md
@@ -22,7 +22,7 @@ For 2018, we are delighted to announce two of our keynotes: Jon Skeet and Chris 
 <div style="clear: both;" />
 
 <br />
-If you have a curiosity for learning and you enjoy learning by doing, or you'd like to try a conference where sessions are interactive and engaging, we invite you to join us for SPA: Software in Practice 2018 on the 4th - 6th July in London.
+If you have a curiosity for learning and you enjoy learning by doing, or you'd like to try a conference where sessions are interactive and engaging, we invite you to join us for SPA: Software in Practice 2018 on {{ site.conference.dates }} in London.
 
 When the schedule is announced, expect to see a variety of topics. Some familiar, including programming languages, agile practices, and architecture, and some new, encouraging us to think more holistically about how we approach software development. Over the past few years, we've enjoyed topics including play in the workplace, knitting and coding, and The Chaos Lottery. To learn more, see [previous years]({{ site.baseurl }}{% link previous-conferences.md %}).
 

--- a/_posts/2018-02-28-launching-spa-2018.md
+++ b/_posts/2018-02-28-launching-spa-2018.md
@@ -5,7 +5,7 @@ date:   2018-02-28 12:00:00 -0000
 categories: announcements keynotes
 ---
 
-Every year, SPA conference unites forward-thinking practitioners with a diverse range of speakers and facilitators. The goal of SPA is to find new and better ways to advance software development; the philosophy is to combine old with new. New topics that challenge us to look at software development in a different way, and new voices to envigorate the community with new ideas.
+Every year, SPA conference unites forward-thinking practitioners with a diverse range of speakers and facilitators. The goal of SPA is to find new and better ways to advance software development; the philosophy is to combine old with new. New topics that challenge us to look at software development in a different way, and new voices to invigorate the community with new ideas.
 
 For 2018, we are delighted to announce two of our keynotes: Jon Skeet and Chris O'Dell. Jon is the leading scorer on StackOverflow.com and Chris is a Continuous Delivery expert and co-author of multiple leading CD books. It's a special line up, and we look forward to making further announcements soon.
 
@@ -24,7 +24,7 @@ For 2018, we are delighted to announce two of our keynotes: Jon Skeet and Chris 
 <br />
 If you have a curiosity for learning and you enjoy learning by doing, or you'd like to try a conference where sessions are interactive and engaging, we invite you to join us for SPA: Software in Practice 2018 on the 4th - 6th July in London.
 
-When the schedule is announced, expect to see a varity of topics. Some familiar, including programming languages, agile practices, and architecture, and some new, encouraging us to think more holistically about how we approach software development. Over the past few years, we've enjoyed topics including play in the workplace, knitting and coding, and The Chaos Lottery. To learn more, see [previous years]({{ site.baseurl }}{% link previous-conferences.md %}).
+When the schedule is announced, expect to see a variety of topics. Some familiar, including programming languages, agile practices, and architecture, and some new, encouraging us to think more holistically about how we approach software development. Over the past few years, we've enjoyed topics including play in the workplace, knitting and coding, and The Chaos Lottery. To learn more, see [previous years]({{ site.baseurl }}{% link previous-conferences.md %}).
 
 <a href="https://spa2018.eventbrite.co.uk/">Tickets</a> are priced at £350 for full access to the entire 3 day event, but until the 31 March 2018, 12 noon, there is a discount of 20% when booking on Eventbrite using discount code SPA201820.
 

--- a/_posts/2018-02-28-launching-spa-2018.md
+++ b/_posts/2018-02-28-launching-spa-2018.md
@@ -12,13 +12,13 @@ For 2018, we are delighted to announce two of our keynotes: Jon Skeet and Chris 
 <div style="float: left; width: 40%; margin-right: 5%; font-size: 0.8em;">
     <img src="{{ '/images/keynote_speakers/Jon_Skeet-13.jpg' | absolute_url }}" style="width: 100%;" alt="Jon Skeet" />
 
-    Jon is a Staff Software Engineer at Google, working in London to make Google Cloud Platform rock for C# developers. When he's not doing that, he enjoys stretching the rules of C# to breaking point, making date and time fun (or at least plausible) to work with in .NET, and posting on Stack Overflow. 
-</div>   
+    Jon is a Staff Software Engineer at Google, working in London to make Google Cloud Platform rock for C# developers. When he's not doing that, he enjoys stretching the rules of C# to breaking point, making date and time fun (or at least plausible) to work with in .NET, and posting on Stack Overflow.
+</div>
 <div style="float: left; width: 40%; font-size: 0.8em">
     <img src="{{ '/images/keynote_speakers/ChrisOdell.JPG' | absolute_url }}" style="width: 100%;" alt="Chris O'Dell" />
 
     Chris has been developing software with Microsoft technologies for over 12 years.  She currently works at Contino helping clients to understand, adopt, and sustain good practices for building and operating software systems.  She has led teams delivering highly available Web APIs, distributed systems and cloud based services.
-</div>  
+</div>
 <div style="clear: both;" />
 
 <br />


### PR DESCRIPTION
Fix a couple of typos and the conference dates in the launch blog post.