### PR TITLE
Add ids to headings on submission stages page

### DIFF
--- a/submission-stages.md
+++ b/submission-stages.md
@@ -6,12 +6,12 @@ has-nav: lead-a-session
 
 <h1>Submission stages</h1>
 <p>We have several stages after submission of proposals to help make the conference the best it can be.</p>
-<h2>Feedback</h2>
+<h2 id="feedback">Feedback</h2>
 <p>The feedback stage is between {{ site.conference.cfp_early_feedback_deadline }} and {{ site.conference.cfp_close_date }}.</p>
 <p>During the feedback stage, we look at all the sessions that were submitted by {{ site.conference.cfp_early_feedback_deadline }} and give them feedback to improve the submission and help make it the best it can be before it goes into the review stage. Sessions can be modified and resubmitted until the final deadline of {{ site.conference.cfp_close_date }}.</p>
 <p>We like each submission to have at least three pieces of feedback, so sessions will be ordered such that those with fewest feedback items are at the top but it's up to you which sessions you give feedback on. The more feedback you have time to give, the better, as it can be very helpful to session proposers, especially those not as familiar with {{ site.conference.name }} or new to presenting.</p>
 <p>At this stage, feedback is seen by the submitter themselves along with everyone else who has access, so it's important to be constructive. Don't forget that some of these people may be submitting to a conference for the first time ever, and your comments may be the first feedback they have received for their conference proposal. The point of this stage is to help submitters make the best proposal they can so ask them to clarify things, suggest modifications to the session, and of course, positive feedback is welcome!</p>
-<h2>Review</h2>
+<h2 id="review">Review</h2>
 <p>The review stage is between {{ site.conference.cfp_close_date }} and {{ site.conference.reviewing_deadline }}.</p>
 <p>During the review stage we are closed to new submissions and existing submissions can't be edited, and this is the stage at which we decide which sessions we'd like to include in the conference. We mark submissions on four criteria:</p>
 <ol><ol>
@@ -25,15 +25,15 @@ has-nav: lead-a-session
 <p>Submitters do not get notified of the reviews, but if they have been involved in the feedback stages (and we encourage everyone to get involved) they will have access so it's still important to be constructive. And it would be bad form to down-vote a session you see as a competitor to one you have submitted!</p>
 <p>Again, ideally we would like every session to receive at least three reviews so that we can be sure the conference will have wide appeal.</p>
 <p>We encourage everyone to get involved in reviewing as well, even if you haven't been to {{ site.conference.name }} before - the basis is whether you would like to attend the session or think it would be valuable.</p>
-<h2>Programme meeting</h2>
+<h2 id="programme-meeting">Programme meeting</h2>
 <p>The programme meeting will be on {{ site.conference.programme_meeting_date }} in Central London. The exact timing and venue will be announced closer to the time. If you would like to be involved in the programme meeting, please contact us.</p>
 <p>At this stage, submissions are still anonymous. We lay out cards with all the sessions and their scores, and formulate a draft programme. High scores are not the only thing we look at, as we want the programme to be as varied and balanced as possible, so we might not want four sessions on Node.js, for example. Those present are also given the opportunity to advocate for particular sessions, for example if it has received average reviews but they feel it would complement other sessions at the conference.</p>
 <p>We then reveal names to check that no-one has too many sessions in, or several at the same time.</p>
 <p>We will contact successful submitters after the programme meeting and we'll announce the programme in {{ site.conference.programme_announce_date }}.</p>
-<h2>Shepherding</h2>
+<h2 id="shepherding">Shepherding</h2>
 <p>All presenters are assigned a shepherd. A shepherd is someone who has experience presenting, maybe at {{ site.conference.name }}, and ideally in a similar area to the session leaders. They offer advice and support to help people prepare their sessions, and may meet with the session leaders and perhaps help arrange dry-runs prior to the conference. (We do recommend that you have at least one dry-run of your session.)</p>
 <p>We are always looking for people to help shepherd, so please do let us know if you'd like to get involved in this.</p>
-<h2>Key dates</h2>
+<h2 id="key-dates">Key dates</h2>
 <ol><ol>
 <ul>
 <li>Feedback: {{ site.conference.cfp_early_feedback_deadline }} &ndash; {{ site.conference.cfp_close_date }}</li>


### PR DESCRIPTION
We want to be able to link directly to the programme meeting section in an
email.