### PR TITLE
Ids for speaker info page

### DIFF
--- a/info-for-speakers.md
+++ b/info-for-speakers.md
@@ -6,14 +6,14 @@ has-nav: lead-a-session
 
 <h1>Information for speakers</h1>
 
-<h2>Shepherding</h2>
+<h2 id="shepherding">Shepherding</h2>
 <p>Soon after your session is accepted we'll assign you a shepherd who will help you make your session the best it can be. A shepherd is someone who has experience presenting, maybe at {{ site.conference.name }}, and ideally in a similar area. They offer advice and support to help you prepare your session, and may meet with you and help arrange dry-runs prior to the conference.</p>
 <p>We do recommend that you have at least one dry-run of your session, both for timings and to try out the interactive elements of your session.</p>
 
-<h2>Tickets</h2>
+<h2 id="tickets">Tickets</h2>
 <p>The first two named presenters of each accepted session receive a free ticket to {{ site.conference.name }}. If you have already purchased a ticket before the programme is announced, contact the organisers to receive a full refund. See our <a href="{{ '/terms-and-conditions.html' | relative_url }}">terms and conditions</a>.</p>
 
-<h2>Expenses</h2>
+<h2 id="expenses">Expenses</h2>
 <p>We would love to be in a position to be able to cover all expenses for every speaker, but as we are a non-profit organisation and the conference is run by volunteers we rely on sponsorship to help with this and have limited funds available.</p>
 <p>If your employer or organisation is able to cover your travel and accommodation expenses, we’d be grateful if you take advantage of that so that we can support other people who need it more. We really don’t want anyone not to present because they can’t afford to come.</p>
 

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -9,7 +9,7 @@ layout: page
 <h3>Conditions of inclusion in programme</h3>
 <ol>
 <li>Final acceptance of proposal will be at the complete discretion of the Programme Chair.</li>
-<li>By agreeing to have the session included in the programme the session leader is committing to participate in the shepherding process to ensure high session quality</li>
+<li>By agreeing to have the session included in the programme the session leader is committing to participate in the shepherding process to ensure high session quality.</li>
 </ol>
 
 <p>The session leader grants the conference organisers the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</p>


### PR DESCRIPTION
Add `id`s to speaker info page headings so that we can link to specific sections in emails.