### PR TITLE
Submissions are closed so remove it from main menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ conference:
       #title: Programme
     - sponsor.md
     # - sponsors.md
-    - lead-a-session.md
+    # - lead-a-session.md
     - organisers.md
     - location.md
     - previous-conferences.md

--- a/lead-a-session.md
+++ b/lead-a-session.md
@@ -4,6 +4,8 @@ layout: page
 has-nav: lead-a-session
 ---
 
+<em>Submissions are now closed for SPA Software in Practice 2018.</em>
+
 <h1>Lead a session</h1>
 <p>{{ site.conference.name }} is about practitioners from any aspect of software development - technology, people and process - sharing their thoughts and knowledge, and learning together.</p>
 <p>All the sessions are interactive - everyone can be an active participant and learn by doing.</p>


### PR DESCRIPTION
This removes the 'Lead a session' from the main navigation menu, but leaves the page in situ so it can still be referred to.

It also adds a comment to the page to indicate that submissions are closed, in case anyone finds their way to the page.