### PR TITLE
Update Terms and Conditions

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
         <p>{{ site.conference.name_with_year }} is organised by
           <a href="http://www.bcs-spa.org/">SPA</a>
           which is a specialist group of the
-          <a href="http://www.bcs.org/">BCS</a>
+          <a href="http://www.bcs.org/">BCS</a>. <a href="{{ "/terms-and-conditions.html" | relative_url }}">Conference Terms and Conditions</a>.
         </p>
       </div>
     </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,7 +19,7 @@
 
   {% if page.url == "/" %}
     <body class="home">
-  {% else if page.url == "/programme_includes/header.html" %}
+  {% elsif page.url == "/programme_includes/header.html" %}
     <body class="programme">
   {% else %}
     <body class="">

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -13,14 +13,19 @@ layout: page
 <li>The session leader grants the conference organisers the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</li>
 <li>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions, or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</li>
 </ol>
-<h3>Use of your data</h3>
-<p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the {{ site.conference.name }} website.</p>
+<h2>Use of your data</h2>
+<p>We use the information you provide when you register with the site in the following ways:</p>
+<p><ol>
+<li>To contact you about your account or about sessions you've submitted.</li>
+<li>If your session is accepted, the information you provide (not including your email address) will be published.</li>
+<li>If you check the box to consent to emails, we may email you about the call for proposals, to ask you to help out with reviewing proposals for next year's conference, and to tell you about future SPA conferences.</li>
+</ol></p>
 
-<p>If you have consented to receive emails about {{ site.conference.name }}, you may be contacted about being involved in the conference (for example, reviewing sessions, or submitting a proposal) and about future conferences.</p>
+<p>We will not sell your data or give it to anyone else.</p>
 
-<p>Your information will not be shared with other groups.</p>
+<p>When sending emails, we may use a client such as MailChimp.</p>
 
 <p>To find out what information is held about you or request deletion of all your information, please contact <a href="mailto:admin@spaconference.org">admin@spaconference.org</a>.</p>
 
-<h3>Other</h3>
+<h2>Other</h2>
 <p>The SPA Specialist Group is not responsible for the views or opinions expressed by individual session leaders, contributors to the SPA wiki, or any individuals who are not members of the executive committee.</p>

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -8,14 +8,11 @@ layout: page
 <p>The first two named presenters of an accepted session will qualify for free attendance at the conference. Session leaders are encouraged to attend the whole conference given the highly interactive nature of the event.</p>
 <h3>Conditions of inclusion in programme</h3>
 <ol>
-<li>Final acceptance of proposal will be at the complete discretion of the Programme Chair.</li>
+<li>Final acceptance of proposal will be at the complete discretion of the Programme Chairs.</li>
 <li>By agreeing to have the session included in the programme the session leader is committing to participate in the shepherding process to ensure high session quality.</li>
+<li>The session leader grants the conference organisers the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</li>
+<li>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions, or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</li>
 </ol>
-
-<p>The session leader grants the conference organisers the right to reproduce and distribute materials submitted for the session for the programme (online and printed). The copyright of the materials remains with the original copyright holder. Where copyright is held by a person other than the session leader, it is the session leader’s responsibility to ensure appropriate permission to use is secured.</p>
-
-<p>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</p>
-
 <h3>Use of your data</h3>
 <p>Those registered with this website are advised that information they provide will be held on computer databases for administrative purposes. If you are leading a session, the information you provide in your profile will be published on the {{ site.conference.name }} website.</p>
 

--- a/terms-and-conditions.md
+++ b/terms-and-conditions.md
@@ -14,12 +14,20 @@ layout: page
 <li>The conference committee has the absolute discretion to remove someone from the programme. This may happen if a session leader has not complied with these terms and conditions, or the  <a href="{{ '/code-of-conduct.html' | relative_url }}" title="Code of Conduct" >code of conduct</a>. If a session is removed from the programme, the session leaders will no longer be eligible for free attendance at the conference.</li>
 </ol>
 <h2>Use of your data</h2>
-<p>We use the information you provide when you register with the site in the following ways:</p>
+<h3>Your email address</h3>
+<p>We use the email address you provide when you register with the site:</p>
 <p><ol>
 <li>To contact you about your account or about sessions you've submitted.</li>
-<li>If your session is accepted, the information you provide (not including your email address) will be published.</li>
-<li>If you check the box to consent to emails, we may email you about the call for proposals, to ask you to help out with reviewing proposals for next year's conference, and to tell you about future SPA conferences.</li>
+<li>If you check the box to consent to emails, we may email you about the call for proposals, to let you know how you can get involved with the conference (e.g. to ask you to help out with reviewing proposals), and to tell you about future SPA conferences.</li>
 </ol></p>
+
+<h3>Your other data</h3>
+<p><ul>
+<li>If your session is accepted, the information you provide (not including your email address) will be published.</li>
+<li>If you submit session proposals, or give feedback or reviews to other sessions, they appear anonymous to other users but can be traced to you in the database through your user ID and your name may be seen by the programme committee at the time of the programme meeting.</li>
+<li>At the end of the annual conference cycle, we delete all feedback, reviews and session proposals from the database. Sessions that appeared in the conference will still appear on that year’s website, but the information is no longer stored in the database.</li>
+<li>Your account may be deleted if your account becomes inactive, for example if you do not log in for five years.</li>
+</ul></p>
 
 <p>We will not sell your data or give it to anyone else.</p>
 


### PR DESCRIPTION
This PR updates the T&Cs for the site to clarify how we use users' data. Comments are very welcome, particularly on whether we need [c598b9d](https://github.com/spaconference/spa-website/commit/c598b9d) or whether that is too much information.