### PR TITLE
Create new headers for different programme pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,6 +21,8 @@
     <body class="home">
   {% elsif page.url == "/programme_includes/header.html" %}
     <body class="programme">
+  {% elsif page.url == "/programme_includes/person_header.html" %}
+    <body class="person">
   {% else %}
     <body class="">
   {% endif %}

--- a/_layouts/programme_page.html
+++ b/_layouts/programme_page.html
@@ -1,0 +1,13 @@
+---
+---
+
+{% include header.html %}
+
+  <div id="main">
+
+      <header><h1 class="inner">
+        {{ page.title }}
+      </h1></header>
+      <div class="inner">
+
+    <main>

--- a/programme_includes/person_header.html
+++ b/programme_includes/person_header.html
@@ -1,4 +1,4 @@
 ---
-title: Programme
+title: Session leader
 layout: programme_page
 ---

--- a/programme_includes/session_header.html
+++ b/programme_includes/session_header.html
@@ -1,4 +1,4 @@
 ---
-title: Programme
+title: Session
 layout: programme_page
 ---


### PR DESCRIPTION
It turns out that the CSS of the session and user pages needs to be differentiated. In previous years this hasn't been a problem because we didn't include the main programme header in the page (e.g. https://spaconference.org/spa2017/sessions/session715.html).

We've now realised that the session and user pages should have the same header as the programme. Like the programme, these pages are generated from inside the PHP scripts so will need to grab the include from the jekyll site (to ensure it's always up to date with the rest of the site).

However, we can't use the same include as the programme because the user page needs a body class of 'person' to display correctly, and the session page requires no body class (rather than 'programme').

The way to make this easiest to understand is to create extra includes (rather than burying some CSS in the PHP), so this commit creates those extra includes (and the clause to select the right one for the user pages). It also pulls out the repeated code into an include.