### PR TITLE
Change documentation so tests run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The `--watch` means that you will not have to restart the server to see changes 
 
 The output of this command will tell you where the site is running locally. It will be something like `localhost:4000/$base_url/` (note the closing slash).
 
-`$base_url` is whatever is set as the `baseurl` in [_config.yml](_config.yml).
+`$base_url` is whatever is set as the `baseurl` in [_config.yml](_config.yml), e.g. `localhost:4000/spa2019`.
 
 To run the tests locally:
 
@@ -32,6 +32,12 @@ bundle exec htmlproofer --assume-extension --url-swap ^/$base_url: ./_site
 ```
 
 where `$base_url` is as above, the `baseurl` in [_config.yml](_config.yml).
+
+e.g.
+
+```
+bundle exec htmlproofer --assume-extension --url-swap ^/spa2019: ./_site
+```
 
 # To update the site
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The output of this command will tell you where the site is running locally. It w
 To run the tests locally:
 
 ```
-bundle exec htmlproofer --assume-extension --url-swap $base_url: ./_site
+bundle exec htmlproofer --assume-extension --url-swap ^/$base_url: ./_site
 ```
 
 where `$base_url` is as above, the `baseurl` in [_config.yml](_config.yml).


### PR DESCRIPTION
One of the issues that caused #56 is swapping out the baseurl wherever it appears in the URL rather than only at the beginning. This PR updates the documentation to show how the tests can be correctly run, and adds some examples.